### PR TITLE
Fix(Logo): Prevent initial particle flash

### DIFF
--- a/src/Logo.tsx
+++ b/src/Logo.tsx
@@ -52,29 +52,29 @@ export const Logo: React.FC<LogoProps> = ({
       {/* These appear first in SVG order, so they render behind the lines */}
 
       {/* Horizontal ellipses - back portions */}
-      <circle r="2.5" fill={finalParticleColor}>
+      <circle r="2.5" fill={finalParticleColor} cx="33" cy="100" opacity="0">
         <animateMotion dur="8s" repeatCount="indefinite" begin="1s" path="M 33,100 A 67,27 0 0,0 167,100 A 67,27 0 0,0 33,100" />
         <animate attributeName="opacity" values="0;1;0.5;0;0" keyTimes="0;0.2;0.4;0.5;1" dur="8s" begin="1s" repeatCount="indefinite" />
       </circle>
-      <circle r="2.5" fill={finalParticleColor}>
+      <circle r="2.5" fill={finalParticleColor} cx="33" cy="100" opacity="0">
         <animateMotion dur="8s" repeatCount="indefinite" begin="2s" path="M 33,100 A 67,40 0 0,0 167,100 A 67,40 0 0,0 33,100" />
         <animate attributeName="opacity" values="0;1;0.5;0;0" keyTimes="0;0.2;0.4;0.5;1" dur="8s" begin="2s" repeatCount="indefinite" />
       </circle>
-      <circle r="2.5" fill={finalParticleColor}>
+      <circle r="2.5" fill={finalParticleColor} cx="33" cy="100" opacity="0">
         <animateMotion dur="8s" repeatCount="indefinite" begin="3s" path="M 33,100 A 67,53 0 0,0 167,100 A 67,53 0 0,0 33,100" />
         <animate attributeName="opacity" values="0;1;0.5;0;0" keyTimes="0;0.2;0.4;0.5;1" dur="8s" begin="3s" repeatCount="indefinite" />
       </circle>
 
       {/* Vertical ellipses - back portions */}
-      <circle r="2.5" fill={finalParticleColor}>
+      <circle r="2.5" fill={finalParticleColor} cx="100" cy="33" opacity="0">
         <animateMotion dur="8s" repeatCount="indefinite" begin="1.5s" path="M 100,33 A 27,67 0 0,0 100,167 A 27,67 0 0,0 100,33" />
         <animate attributeName="opacity" values="0;1;0.5;0;0" keyTimes="0;0.2;0.4;0.5;1" dur="8s" begin="1.5s" repeatCount="indefinite" />
       </circle>
-      <circle r="2.5" fill={finalParticleColor}>
+      <circle r="2.5" fill={finalParticleColor} cx="100" cy="33" opacity="0">
         <animateMotion dur="8s" repeatCount="indefinite" begin="2.5s" path="M 100,33 A 40,67 0 0,0 100,167 A 40,67 0 0,0 100,33" />
         <animate attributeName="opacity" values="0;1;0.5;0;0" keyTimes="0;0.2;0.4;0.5;1" dur="8s" begin="2.5s" repeatCount="indefinite" />
       </circle>
-      <circle r="2.5" fill={finalParticleColor}>
+      <circle r="2.5" fill={finalParticleColor} cx="100" cy="33" opacity="0">
         <animateMotion dur="8s" repeatCount="indefinite" begin="3.5s" path="M 100,33 A 53,67 0 0,0 100,167 A 53,67 0 0,0 100,33" />
         <animate attributeName="opacity" values="0;1;0.5;0;0" keyTimes="0;0.2;0.4;0.5;1" dur="8s" begin="3.5s" repeatCount="indefinite" />
       </circle>
@@ -330,29 +330,29 @@ export const Logo: React.FC<LogoProps> = ({
       {/* These appear last in SVG order, so they render on top of the lines */}
 
       {/* Horizontal ellipses - front portions */}
-      <circle r="2.5" fill={finalParticleColor}>
+      <circle r="2.5" fill={finalParticleColor} cx="33" cy="100" opacity="0">
         <animateMotion dur="8s" repeatCount="indefinite" begin="1s" path="M 33,100 A 67,27 0 0,0 167,100 A 67,27 0 0,0 33,100" />
         <animate attributeName="opacity" values="0;0;0.5;1;1;0.5;0" keyTimes="0;0.5;0.6;0.75;0.9;0.95;1" dur="8s" begin="1s" repeatCount="indefinite" />
       </circle>
-      <circle r="2.5" fill={finalParticleColor}>
+      <circle r="2.5" fill={finalParticleColor} cx="33" cy="100" opacity="0">
         <animateMotion dur="8s" repeatCount="indefinite" begin="2s" path="M 33,100 A 67,40 0 0,0 167,100 A 67,40 0 0,0 33,100" />
         <animate attributeName="opacity" values="0;0;0.5;1;1;0.5;0" keyTimes="0;0.5;0.6;0.75;0.9;0.95;1" dur="8s" begin="2s" repeatCount="indefinite" />
       </circle>
-      <circle r="2.5" fill={finalParticleColor}>
+      <circle r="2.5" fill={finalParticleColor} cx="33" cy="100" opacity="0">
         <animateMotion dur="8s" repeatCount="indefinite" begin="3s" path="M 33,100 A 67,53 0 0,0 167,100 A 67,53 0 0,0 33,100" />
         <animate attributeName="opacity" values="0;0;0.5;1;1;0.5;0" keyTimes="0;0.5;0.6;0.75;0.9;0.95;1" dur="8s" begin="3s" repeatCount="indefinite" />
       </circle>
 
       {/* Vertical ellipses - front portions */}
-      <circle r="2.5" fill={finalParticleColor}>
+      <circle r="2.5" fill={finalParticleColor} cx="100" cy="33" opacity="0">
         <animateMotion dur="8s" repeatCount="indefinite" begin="1.5s" path="M 100,33 A 27,67 0 0,0 100,167 A 27,67 0 0,0 100,33" />
         <animate attributeName="opacity" values="0;0;0.5;1;1;0.5;0" keyTimes="0;0.5;0.6;0.75;0.9;0.95;1" dur="8s" begin="1.5s" repeatCount="indefinite" />
       </circle>
-      <circle r="2.5" fill={finalParticleColor}>
+      <circle r="2.5" fill={finalParticleColor} cx="100" cy="33" opacity="0">
         <animateMotion dur="8s" repeatCount="indefinite" begin="2.5s" path="M 100,33 A 40,67 0 0,0 100,167 A 40,67 0 0,0 100,33" />
         <animate attributeName="opacity" values="0;0;0.5;1;1;0.5;0" keyTimes="0;0.5;0.6;0.75;0.9;0.95;1" dur="8s" begin="2.5s" repeatCount="indefinite" />
       </circle>
-      <circle r="2.5" fill={finalParticleColor}>
+      <circle r="2.5" fill={finalParticleColor} cx="100" cy="33" opacity="0">
         <animateMotion dur="8s" repeatCount="indefinite" begin="3.5s" path="M 100,33 A 53,67 0 0,0 100,167 A 53,67 0 0,0 100,33" />
         <animate attributeName="opacity" values="0;0;0.5;1;1;0.5;0" keyTimes="0;0.5;0.6;0.75;0.9;0.95;1" dur="8s" begin="3.5s" repeatCount="indefinite" />
       </circle>


### PR DESCRIPTION
The animated SVG particles were briefly appearing at the default (0,0) coordinate before their animations started. This caused a visual glitch where dots would flash in the top-left corner of the component on load.

This change resolves the issue by setting the initial `cx` and `cy` attributes of each animated `<circle>` to match the starting point of its corresponding animation path. It also sets the initial `opacity` to `0` to ensure a smooth fade-in effect managed by the animation.